### PR TITLE
fix build errors, remove manually assigning part names, and update to…

### DIFF
--- a/Kissable.cs
+++ b/Kissable.cs
@@ -17,16 +17,6 @@ namespace XRL.World.Parts
 		[NonSerialized]
 		public List<acegiak_KissingPreference> preferences = null;
 
-
-
-		public acegiak_Kissable()
-		{
-			base.Name = "acegiak_Kissable";
-			//DisplayName = "Kissable";
-			
-		}
-
-
 		public override bool SameAs(IPart p)
 		{
 			return false;
@@ -251,7 +241,7 @@ namespace XRL.World.Parts
             if (E.ID == "GetInventoryActions")
 			{
 				if(ParentObject.pBrain.GetFeeling(E.GetGameObjectParameter("Owner")) > 0){
-					E.GetParameter<EventParameterGetInventoryActions>("Actions").AddAction("Kiss", 'k',  false, "&Wk&yiss", "InvCommandKiss", 10);
+					E.GetParameter<EventParameterGetInventoryActions>("Actions").AddAction("Kiss", 'k',  false, "&Wk&yiss", "InvCommandKiss", null, 10);
 				}
 			}
 			if (E.ID == "InvCommandKiss" && Kiss(E.GetGameObjectParameter("Owner")))

--- a/RomancablePart.cs
+++ b/RomancablePart.cs
@@ -1,5 +1,6 @@
 using System;
 using XRL.Core;
+using XRL.Names;
 using XRL.UI;
 using XRL.Rules;
 using XRL.World.AI.GoalHandlers;
@@ -46,14 +47,6 @@ namespace XRL.World.Parts
 
 		public int? lastQuestion = null;
 		public string namegenerated = null;
-
-
-
-		public acegiak_Romancable()
-		{
-			base.Name = "acegiak_Romancable";
-			
-		}
 
 		public void havePreference(){
 			if(ParentObject.IsPlayer()){
@@ -171,7 +164,7 @@ namespace XRL.World.Parts
 		{
 			Object.RegisterPartEvent(this, "GetInventoryActions");
 			Object.RegisterPartEvent(this, "InvCommandGift");
-			Object.RegisterPartEvent(this, "PlayerBeginConversation");
+			Object.RegisterPartEvent(this, "BeginConversation");
 			Object.RegisterPartEvent(this, "ShowConversationChoices");
 			Object.RegisterPartEvent(this, "VisitConversationNode");
 			Object.RegisterPartEvent(this, "OwnerGetInventoryActions");
@@ -472,7 +465,7 @@ namespace XRL.World.Parts
 			if(!ParentObject.HasProperName
 			&& namegenerated == null
 			&& ParentObject.pBrain.GetFeeling(XRLCore.Core.Game.Player.Body)>7){
-				namegenerated = HeroMaker.MakeHeroName(ParentObject, new string[0], new string[0], bIncludeTitle: false);
+				namegenerated = NameMaker.MakeName(ParentObject);
 				ParentObject.SetIntProperty("ProperNoun", 1);
 				ParentObject.SetIntProperty("Renamed", 1);
 				node.Text = "["+ParentObject.The+ParentObject.pRender.DisplayName+" tells you "+ParentObject.its+" name: "+namegenerated+"]\n\n"+node.Text;
@@ -493,23 +486,23 @@ namespace XRL.World.Parts
 
 
 		public override bool FireEvent(Event E){
-            if (E.ID == "GetInventoryActions")
+			if (E.ID == "GetInventoryActions")
 			{
 				if(
 					//ParentObject.pBrain.GetFeeling(XRLCore.Core.Game.Player.Body)>5 && 
 					!ParentObject.IsPlayer()){
-					E.GetParameter<EventParameterGetInventoryActions>("Actions").AddAction("Gift", 'G',  false, "&Wg&yift", "InvCommandGift", 10);
+					E.GetParameter<EventParameterGetInventoryActions>("Actions").AddAction("Gift", 'G',  false, "&Wg&yift", "InvCommandGift", null, 10);
 				}
 			}
 			if (E.ID == "InvCommandGift" && Gift(E.GetGameObjectParameter("Owner"), FromDialog: true))
 			{
 				E.RequestInterfaceExit();
 			}
-			if (E.ID == "PlayerBeginConversation")
+			if (E.ID == "BeginConversation")
 			{
 				if(ParentObject.pBrain.GetFeeling(XRLCore.Core.Game.Player.Body)>0){
-					HandleBeginConversation(E.GetParameter<Conversation>("Conversation"),E.GetParameter<GameObject>("Speaker"));
-					GameObject speaker = E.GetParameter<GameObject>("Speaker");
+					HandleBeginConversation(E.GetParameter<Conversation>("Conversation"),E.GetParameter<GameObject>("Actor"));
+					GameObject speaker = E.GetParameter<GameObject>("Actor");
 					if(speaker.GetPart<acegiak_Romancable>() != null){
 							
 						float patienceRate = 200f; //DEFAULT: 1200

--- a/RomanceChatChoice.cs
+++ b/RomanceChatChoice.cs
@@ -21,7 +21,7 @@ namespace XRL.World
         public string action = null;
 
 
-		public override ConversationNode Goto(GameObject Speaker, bool peekOnly = false)
+		public override ConversationNode Goto(GameObject Speaker, bool peekOnly = false, Conversation conversation = null)
 		{
             if(!peekOnly){
                 if (action == "*Kiss")
@@ -61,7 +61,7 @@ namespace XRL.World
                     choiceAction.Invoke();
                 }
             }
-            ConversationNode goingto = base.Goto(Speaker,peekOnly);
+            ConversationNode goingto = base.Goto(Speaker, peekOnly, conversation);
 			if(goingto != null && goingto is acegiak_RomanceChatNode){
                 goingto.Text = this.ResponseText;
             }


### PR DESCRIPTION
… use speaker-based conversation event.

The mod now is functioning as of the palladium reef beta version. It probably works with stable too, I just haven't tested it and probably wont given the reef is being fully released in less than two weeks. 

Besides fixing the build errors, the main update that restored the 'Let's Chat' option to NPCs was the change from PlayerBeginConversation -> BeginConversation. I confirmed that chatting works now, or at least it appears to. I haven't tested any functionality besides going through a few rounds of q&a with some Joppa villagers from beginning to end. I don't think I actually tested the change to using NameMaker.name but it compiles at least.
